### PR TITLE
Add interval merge solution in Go

### DIFF
--- a/.github/workflows/interval_merge.yaml
+++ b/.github/workflows/interval_merge.yaml
@@ -54,7 +54,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+          # Use stable since Go is forwards-compatibility for all Go 1.x versions
+          # and the code should keep compiling with newer versions.
+          # Go std is the only dependency.
+        go-version: 'stable'
     - name: Build
       run: go build -v
     - name: Test

--- a/.github/workflows/interval_merge.yaml
+++ b/.github/workflows/interval_merge.yaml
@@ -44,3 +44,20 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --tests --all-features -- -D warnings
       - run: cargo test --verbose --all-features 
+  go:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: interval_merge/go
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.20'
+    - name: Build
+      run: go build -v
+    - name: Test
+      run: go test -v
+    - name: Benchmark
+      run: go test -v -bench Benchmark*

--- a/interval_merge/go/README.md
+++ b/interval_merge/go/README.md
@@ -1,0 +1,30 @@
+# Interval merge in Go
+
+Implementation of the merge interval challenge with Go. The function is called `Merge`.
+
+The functions `MergeStream` and `MergeFleet` are experiments with using channels as input and
+goroutines as workers. Based on benchmark feedback, they perform under most scenarios significant worse than the `Merge` function.
+The `MergeFleet` also has a bug which randomly appears. Seems like a race condition.
+
+```
+    --- FAIL: TestMerge/MergeFleet_with_negative_ranges (0.00s)
+        merge_test.go:93: Expected [{-4 0} {-1 2}] to be merged to [{-4 2}], got [{-4 0}]
+```
+
+## Requirements
+
+[Go](https://go.dev/doc/install)
+
+## Run
+
+Only tests and benchmarks available. Run the tests with
+
+```bash
+go test
+```
+
+and the benchmarks with 
+```bash
+go test -bench Benchmark*
+```
+

--- a/interval_merge/go/go.mod
+++ b/interval_merge/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/marshauf/coding_challenges/interval_merge/go
+
+go 1.20

--- a/interval_merge/go/merge.go
+++ b/interval_merge/go/merge.go
@@ -9,10 +9,6 @@ func New(start, end int) Interval {
 	return Interval{start, end}
 }
 
-func (i Interval) contains(point int) bool {
-	return i.start < point && point < i.end
-}
-
 func Merge(intervals []Interval) []Interval {
 	merged_intervals := make([]Interval, 0, 8)
 	for _, interval := range intervals {

--- a/interval_merge/go/merge.go
+++ b/interval_merge/go/merge.go
@@ -1,14 +1,22 @@
 package interval
 
+// An Interval is a range with a lower and upper bound.
+// The lower bound is inclusive, the upper bound is exclusive.
 type Interval struct {
-	start int
-	end   int
+	start int // lower bound
+	end   int // upper bound
 }
 
+// New creates a new Interval with start as lower bound and end as upper bound.
 func New(start, end int) Interval {
 	return Interval{start, end}
 }
 
+// Merges all intervals together which overlap.
+// Resulting in a sorted slice of Intervals, where no Interval overlaps another.
+// Intervals are bound inclusively below and exclusively above.
+// Which means when an Interval upper bound is the same as another Intervals lower bound,
+// both intervals don't overlap.
 func Merge(intervals []Interval) []Interval {
 	merged_intervals := make([]Interval, 0, 8)
 	for _, interval := range intervals {
@@ -17,6 +25,12 @@ func Merge(intervals []Interval) []Interval {
 	return merged_intervals
 }
 
+// merge_into merges one interval into the provided slice and returns it.
+// It either gets prepended if it is smaller than the first element,
+// or append if it is larger than the last element.
+// If the interval overlaps with another, source is merged into the matched element.
+// If the upper bound grew after merge, a rollup happens. See rollup function.
+// The length of the slice might grow by one or shrink down to one.
 func merge_into(source Interval, intervals []Interval) []Interval {
 	for i, interval := range intervals {
 		// Does source end before interval?
@@ -39,12 +53,17 @@ func merge_into(source Interval, intervals []Interval) []Interval {
 			return rollup(intervals, i, intervals[i].end)
 		}
 	}
+	// source is larger than any interval in intervals
 	intervals = append(intervals, source)
 	return intervals
 }
 
+// rollup merges all overlapping intervals together starting at from, which are smaller than end.
+// End changes on merge to the higher value of either end or the upper bound of the merged interval.
+// from is the index of the interval in intervals, which started the rollup because its upper bound grew.
 func rollup(intervals []Interval, from int, end int) []Interval {
 	for i, interval := range intervals[from+1:] {
+		// is interval smaller than the upper bound?
 		if interval.start < end {
 			end = max(end, interval.end)
 			// Re-slicing is expensive, could be optimized by storing the to be deleted ranges
@@ -55,6 +74,7 @@ func rollup(intervals []Interval, from int, end int) []Interval {
 	return intervals
 }
 
+// min returns the smallest number of n or m
 func min(n, m int) int {
 	if n < m {
 		return n
@@ -62,6 +82,7 @@ func min(n, m int) int {
 	return m
 }
 
+// max returns the largest number of n or m
 func max(n, m int) int {
 	if n > m {
 		return n

--- a/interval_merge/go/merge.go
+++ b/interval_merge/go/merge.go
@@ -62,13 +62,20 @@ func merge_into(source Interval, intervals []Interval) []Interval {
 // End changes on merge to the higher value of either end or the upper bound of the merged interval.
 // from is the index of the interval in intervals, which started the rollup because its upper bound grew.
 func rollup(intervals []Interval, from int, end int) []Interval {
+	n := -1
 	for i, interval := range intervals[from+1:] {
 		// is interval smaller than the upper bound?
 		if interval.start < end {
 			end = max(end, interval.end)
-			// Re-slicing is expensive, could be optimized by storing the to be deleted ranges
-			intervals = append(intervals[:i+from+1], intervals[i+from+2:]...)
+			n = from + 1 + i
+		} else {
+			// All following intervals are larger than end, break
+			break
 		}
+	}
+	// Slice if merge happened
+	if n > -1 {
+		intervals = append(intervals[:from+1], intervals[n+1:]...)
 	}
 	intervals[from].end = end
 	return intervals

--- a/interval_merge/go/merge.go
+++ b/interval_merge/go/merge.go
@@ -39,7 +39,7 @@ func merge_into(source Interval, intervals []Interval) []Interval {
 			return intervals
 		}
 		// Is source start inside interval?
-		if source.start > interval.start && source.start < interval.end {
+		if source.start >= interval.start && source.start < interval.end {
 			intervals[i].end = max(interval.end, source.end)
 			return rollup(intervals, i, intervals[i].end)
 		}

--- a/interval_merge/go/merge.go
+++ b/interval_merge/go/merge.go
@@ -14,18 +14,61 @@ func (i Interval) contains(point int) bool {
 }
 
 func Merge(intervals []Interval) []Interval {
+	merged_intervals := make([]Interval, 0, 8)
 	for _, interval := range intervals {
-		intervals = merge_into(interval, intervals)
+		merged_intervals = merge_into(interval, merged_intervals)
 	}
-	return intervals
+	return merged_intervals
 }
 
 func merge_into(source Interval, intervals []Interval) []Interval {
-
-	for _, interval := range intervals {
-		if source.end < interval.start {
+	for i, interval := range intervals {
+		// Does source end before interval?
+		if source.end <= interval.start {
 			intervals = append([]Interval{source}, intervals...)
+			return intervals
+		}
+		// Is source start inside interval?
+		if source.start > interval.start && source.start < interval.end {
+			intervals[i].end = max(interval.end, source.end)
+			return rollup(intervals, i, intervals[i].end)
+		}
+		// Is source end inside interval?
+		if source.end < interval.end {
+			intervals[i].start = min(interval.start, source.start)
+		}
+		// Is interval inside source?
+		if interval.start >= source.start && interval.start < source.end {
+			intervals[i] = source
+			return rollup(intervals, i, intervals[i].end)
 		}
 	}
+	intervals = append(intervals, source)
 	return intervals
+}
+
+func rollup(intervals []Interval, from int, end int) []Interval {
+	for i, interval := range intervals[from+1:] {
+		if interval.start < end {
+			end = max(end, interval.end)
+			// Re-slicing is expensive, could be optimized by storing the to be deleted ranges
+			intervals = append(intervals[:i+from+1], intervals[i+from+2:]...)
+		}
+	}
+	intervals[from].end = end
+	return intervals
+}
+
+func min(n, m int) int {
+	if n < m {
+		return n
+	}
+	return m
+}
+
+func max(n, m int) int {
+	if n > m {
+		return n
+	}
+	return m
 }

--- a/interval_merge/go/merge.go
+++ b/interval_merge/go/merge.go
@@ -1,0 +1,31 @@
+package interval
+
+type Interval struct {
+	start int
+	end   int
+}
+
+func New(start, end int) Interval {
+	return Interval{start, end}
+}
+
+func (i Interval) contains(point int) bool {
+	return i.start < point && point < i.end
+}
+
+func Merge(intervals []Interval) []Interval {
+	for _, interval := range intervals {
+		intervals = merge_into(interval, intervals)
+	}
+	return intervals
+}
+
+func merge_into(source Interval, intervals []Interval) []Interval {
+
+	for _, interval := range intervals {
+		if source.end < interval.start {
+			intervals = append([]Interval{source}, intervals...)
+		}
+	}
+	return intervals
+}

--- a/interval_merge/go/merge_test.go
+++ b/interval_merge/go/merge_test.go
@@ -103,3 +103,15 @@ func BenchmarkMerge(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkMergeWithHugeRollup(b *testing.B) {
+	intervals := make([]interval.Interval, 1_000)
+	for i := range intervals {
+		intervals[i] = interval.New(i, i+1)
+	}
+	intervals[len(intervals)-1] = interval.New(0, len(intervals))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		interval.Merge(intervals)
+	}
+}

--- a/interval_merge/go/merge_test.go
+++ b/interval_merge/go/merge_test.go
@@ -1,8 +1,11 @@
 package interval_test
 
 import (
-	interval "github.com/marshauf/coding_challenges/interval_merge/go"
+	"fmt"
+	"math/rand"
 	"testing"
+
+	interval "github.com/marshauf/coding_challenges/interval_merge/go"
 )
 
 type row struct {
@@ -60,6 +63,39 @@ func TestMerge(t *testing.T) {
 				t.Errorf("Expected %v to be merged to %v, got %v", row.input, row.expected, res)
 			}
 
+		})
+	}
+}
+
+func generateBenchmarkInput(size int, seed int64) []interval.Interval {
+	r := rand.New(rand.NewSource(seed))
+	intervalMaxSize := 10
+	intervalMaxStart := size * 100
+
+	intervals := make([]interval.Interval, size)
+	for i := range intervals {
+		start := r.Intn(intervalMaxStart)
+		end := start + r.Intn(intervalMaxSize)
+		intervals[i] = interval.New(start, end)
+	}
+	return intervals
+}
+
+func BenchmarkMerge(b *testing.B) {
+	table := []struct{ size int }{
+		{size: 1},
+		{size: 10},
+		{size: 100},
+		{size: 1_000},
+		{size: 10_000},
+	}
+	for _, row := range table {
+		b.Run(fmt.Sprintf("size_%d", row.size), func(b *testing.B) {
+			intervals := generateBenchmarkInput(row.size, 0)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				interval.Merge(intervals)
+			}
 		})
 	}
 }

--- a/interval_merge/go/merge_test.go
+++ b/interval_merge/go/merge_test.go
@@ -1,0 +1,65 @@
+package interval_test
+
+import (
+	interval "github.com/marshauf/coding_challenges/interval_merge/go"
+	"testing"
+)
+
+type row struct {
+	name     string
+	input    []interval.Interval
+	expected []interval.Interval
+}
+
+func equal(a, b []interval.Interval) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestMerge(t *testing.T) {
+	table := []row{
+		{
+			name:     "Empty",
+			input:    []interval.Interval{},
+			expected: []interval.Interval{},
+		}, {
+			name:     "One",
+			input:    []interval.Interval{interval.New(0, 1)},
+			expected: []interval.Interval{interval.New(0, 1)},
+		}, {
+			name:     "intervals which do not overlap",
+			input:    []interval.Interval{interval.New(0, 1), interval.New(2, 3), interval.New(5, 12)},
+			expected: []interval.Interval{interval.New(0, 1), interval.New(2, 3), interval.New(5, 12)},
+		}, {
+			name:     "example",
+			input:    []interval.Interval{interval.New(25, 30), interval.New(2, 19), interval.New(14, 23), interval.New(4, 8)},
+			expected: []interval.Interval{interval.New(2, 23), interval.New(25, 30)},
+		}, {
+			name:     "example with an interval at the end, which includes all intervals before it",
+			input:    []interval.Interval{interval.New(25, 30), interval.New(2, 19), interval.New(14, 23), interval.New(4, 8), interval.New(0, 40)},
+			expected: []interval.Interval{interval.New(0, 40)},
+		}, {
+			name:     "negative ranges",
+			input:    []interval.Interval{interval.New(-4, 0), interval.New(-1, 2)},
+			expected: []interval.Interval{interval.New(-4, 2)},
+		},
+	}
+
+	for _, row := range table {
+		t.Run(row.name, func(t *testing.T) {
+			res := interval.Merge(row.input)
+
+			if !equal(res, row.expected) {
+				t.Errorf("Expected %v to be merged to %v, got %v", row.input, row.expected, res)
+			}
+
+		})
+	}
+}

--- a/interval_merge/go/merge_test.go
+++ b/interval_merge/go/merge_test.go
@@ -52,6 +52,10 @@ func TestMerge(t *testing.T) {
 			name:     "negative ranges",
 			input:    []interval.Interval{interval.New(-4, 0), interval.New(-1, 2)},
 			expected: []interval.Interval{interval.New(-4, 2)},
+		}, {
+			name:     "rollup slice bounds out of range",
+			input:    []interval.Interval{interval.New(0, 1), interval.New(2, 3), interval.New(3, 4), interval.New(4, 5), interval.New(0, 5)},
+			expected: []interval.Interval{interval.New(0, 5)},
 		},
 	}
 


### PR DESCRIPTION
# Interval merge challenge

## Description

Implements a `Merge` function, which takes a list of intervals and returns a list of intervals.
All overlapping intervals are merged in the returned list. All none overlapping intervals are returned unmodified.

## Example

```
Input: [25,30] [2,19] [14, 23] [4,8]
Output: [2,23] [25,30]
```

TODO

- [x] Implement the merge algorithm
- [x] Write benchmark
- [x] Add workflow to execute tests and benchmarks
- [x] Add documentation
- [x] Add concurrent execution on top with streamed input to handle inputs larger than available memory

## Note

`MergeStream` and `MergeFleet` are experimental and shouldn't be used. They require additional work.